### PR TITLE
Fixed camera release crash

### DIFF
--- a/app/src/main/java/hypr/a255bits/com/hypr/CameraFragment/CameraActivity.kt
+++ b/app/src/main/java/hypr/a255bits/com/hypr/CameraFragment/CameraActivity.kt
@@ -49,8 +49,8 @@ class CameraActivity : AppCompatActivity(), CameraMVP.view {
         }
     }
 
-    override fun onStart() {
-        super.onStart()
+    override fun onResume() {
+        super.onResume()
         cameraView.start()
     }
 

--- a/app/src/main/res/layout/activity_camera.xml
+++ b/app/src/main/res/layout/activity_camera.xml
@@ -12,6 +12,7 @@
         android:id="@+id/cameraView"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        app:ckPermissions="picture"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintLeft_toLeftOf="parent"
@@ -42,7 +43,7 @@
         android:layout_marginBottom="8dp"
         android:layout_marginLeft="8dp"
         android:layout_marginRight="8dp"
-        android:text="Take Picture"
+        android:text="@string/take_picture"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,5 @@
 
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="take_picture">Take Picture</string>
 </resources>


### PR DESCRIPTION
Camera crashing after picking image 2-3 times fixed.

LOG: 

Exception java.lang.RuntimeException: Camera is being used after Camera.release() was called
android.hardware.Camera.native_setParameters (Camera.java)
android.hardware.Camera.setParameters (Camera.java:1898)
com.flurgle.camerakit.Camera1.setFlash (Camera1.java:139)
com.flurgle.camerakit.Camera1.adjustCameraParameters (Camera1.java:376)
com.flurgle.camerakit.Camera1.openCamera (Camera1.java:317)
com.flurgle.camerakit.Camera1.start (Camera1.java:85)
com.flurgle.camerakit.CameraView$3.run (CameraView.java:216)
java.lang.Thread.run (Thread.java:764)