### PR TITLE
Fixed billing problem

### DIFF
--- a/app/src/main/java/hypr/a255bits/com/hypr/Main/MainInteractor.kt
+++ b/app/src/main/java/hypr/a255bits/com/hypr/Main/MainInteractor.kt
@@ -75,7 +75,7 @@ class MainInteractor(val context: Context) : MainMvp.interactor {
 
     override fun stopInAppBilling() {
         if(billingHelper.isConnected){
-            billingHelper.dispose()
+            billingHelper.disposeWhenFinished()
         }
     }
 


### PR DESCRIPTION
When opening the purchasing popup, closing that, then going to the camera the app would crash. Fixed now. 